### PR TITLE
Propagate versions defined in the manifest

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ Promise.resolve()
 
   const newManifest = {
     manifest_version: 2,
-    version:          '1.0.0',
+    version:          manifest.version || '1.0.0',
     short_name:       manifest.short_name,
     name:             manifest.name,
     background:       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-react-app-chrome-extension",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Turn a basic create-react-app application into a chrome extension with one line.",
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
Fixes #2 by considering the `manifest.json`'s `version` property if it exists. Otherwise it falls back to the existing behaviour of 1.0.0.

Any falsy values are likely to cause issues downstream hence using `||` is acceptable. 